### PR TITLE
Settings button

### DIFF
--- a/dmpcatalogue/gui/dock_widget.py
+++ b/dmpcatalogue/gui/dock_widget.py
@@ -84,7 +84,9 @@ class CatalogueDockWidget(QgsDockWidget, WIDGET):
         )
         self.group_owners_action.toggled.connect(self.toggle_group_owners)
 
-        self.options_action.setIcon(QgsApplication.getThemeIcon("/mActionOptions.svg"))
+        self.options_action.setIcon(
+            QgsApplication.getThemeIcon("/mActionOptions.svg")
+        )
         self.options_action.triggered.connect(self.open_plugin_options)
 
         col_menu = QMenu()

--- a/dmpcatalogue/gui/dock_widget.py
+++ b/dmpcatalogue/gui/dock_widget.py
@@ -84,6 +84,9 @@ class CatalogueDockWidget(QgsDockWidget, WIDGET):
         )
         self.group_owners_action.toggled.connect(self.toggle_group_owners)
 
+        self.options_action.setIcon(QgsApplication.getThemeIcon("/mActionOptions.svg"))
+        self.options_action.triggered.connect(self.open_plugin_options)
+
         col_menu = QMenu()
         all_col_action = col_menu.addAction(self.tr("All"))
         all_col_action.setCheckable(True)

--- a/dmpcatalogue/plugin.py
+++ b/dmpcatalogue/plugin.py
@@ -55,7 +55,9 @@ class DmpPlugin:
         self.dock_action.setCheckable(True)
         self.dock_action.toggled.connect(self.toggle_dock_widget)
 
-        self.settings_action = QAction(self.tr("Settings"), self.iface.mainWindow())
+        self.settings_action = QAction(
+            self.tr("Settings"), self.iface.mainWindow()
+        )
         self.settings_action.setIcon(
             QgsApplication.getThemeIcon("/mActionOptions.svg")
         )

--- a/dmpcatalogue/plugin.py
+++ b/dmpcatalogue/plugin.py
@@ -55,6 +55,13 @@ class DmpPlugin:
         self.dock_action.setCheckable(True)
         self.dock_action.toggled.connect(self.toggle_dock_widget)
 
+        self.settings_action = QAction(self.tr("Settings"), self.iface.mainWindow())
+        self.settings_action.setIcon(
+            QgsApplication.getThemeIcon("/mActionOptions.svg")
+        )
+        self.settings_action.setObjectName("dmpCatalogueSettings")
+        self.settings_action.triggered.connect(self.open_settings)
+
         self.help_action = QAction(self.tr("Help"), self.iface.mainWindow())
         self.help_action.setIcon(
             QgsApplication.getThemeIcon("/mActionHelpContents.svg")
@@ -64,6 +71,9 @@ class DmpPlugin:
 
         self.iface.addPluginToWebMenu(
             self.tr("DMP Catalogue"), self.dock_action
+        )
+        self.iface.addPluginToWebMenu(
+            self.tr("DMP Catalogue"), self.settings_action
         )
         self.iface.addPluginToWebMenu(
             self.tr("DMP Catalogue"), self.help_action
@@ -76,6 +86,9 @@ class DmpPlugin:
     def unload(self):
         self.iface.removePluginWebMenu(
             self.tr("DMP Catalogue"), self.dock_action
+        )
+        self.iface.removePluginWebMenu(
+            self.tr("DMP Catalogue"), self.settings_action
         )
         self.iface.removePluginWebMenu(
             self.tr("DMP Catalogue"), self.help_action
@@ -100,6 +113,9 @@ class DmpPlugin:
                 "blob/master/README.md"
             )
         )
+
+    def open_settings(self):
+        self.iface.showOptionsDialog(self.iface.mainWindow(), "dmpOptions")
 
     def report_error(self, message):
         self.iface.messageBar().pushMessage(

--- a/dmpcatalogue/ui/catalogue_widget.ui
+++ b/dmpcatalogue/ui/catalogue_widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>289</width>
+    <width>284</width>
     <height>438</height>
    </rect>
   </property>
@@ -71,6 +71,7 @@
           </property>
           <addaction name="datasources_source_action"/>
           <addaction name="group_owners_action"/>
+          <addaction name="options_action"/>
          </widget>
         </item>
         <item>
@@ -121,6 +122,7 @@
            <bool>false</bool>
           </property>
           <addaction name="collections_source_action"/>
+          <addaction name="options_action"/>
          </widget>
         </item>
         <item>


### PR DESCRIPTION
Add a button to open plugin settings to the dock toolbar to make users more aware about the fact that plugin has settings.