### PR TITLE
Fix 'download limit has been reached' warning

### DIFF
--- a/dmpcatalogue/core/data_classes.py
+++ b/dmpcatalogue/core/data_classes.py
@@ -155,6 +155,7 @@ class WfsSource(Datasource):
         uri = QgsDataSourceUri()
         uri.setParam("url", url)
         uri.setParam("typename", self.typename)
+        uri.setParam('restrictToRequestBBOX', '1')
 
         layer = QgsVectorLayer(uri.uri(), title, "wfs")
         return layer


### PR DESCRIPTION
The `restrictToRequestBBOX` parameter ensure that only features in the view extent (or more generally in the bounding box of the feature iterator) is downloaded.

Without it, the following warning would be shown, and only a few features were downloaded and added:

```
2024-08-20T16:39:51     WARNING    mat:Jordstykke_Gaeldende: The
download limit has been reached. You may want to check the 'Only request
features overlapping the view extent' option to be able to zoom in to
fetch all data.
```